### PR TITLE
Add initial React timer configuration screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Good.ia</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" data-type="module" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/TimerConfigScreen.jsx
+++ b/frontend/src/TimerConfigScreen.jsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+export default function TimerConfigScreen() {
+  const [frequency, setFrequency] = useState('1h');
+
+  const handleChange = (e) => setFrequency(e.target.value);
+  const handleSave = () => {
+    alert(`Frequência salva: ${frequency}`);
+  };
+
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h1>Timer de Elogios</h1>
+      <p>Escolha a frequência das mensagens:</p>
+      <select value={frequency} onChange={handleChange}>
+        <option value="1h">A cada 1 hora</option>
+        <option value="3h">A cada 3 horas</option>
+        <option value="6h">A cada 6 horas</option>
+        <option value="24h">Uma vez por dia</option>
+      </select>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={handleSave}>Salvar</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import TimerConfigScreen from './TimerConfigScreen.jsx';
+
+const rootElement = document.getElementById('root');
+const root = createRoot(rootElement);
+root.render(<TimerConfigScreen />);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "goodia",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold basic React frontend with timer configuration screen
- provide package.json with placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6894d7d1d8ac83259e36bb9a76c4e98b