### PR TITLE
Add TriboFit CLI prototype and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# TriboFit
+
+Protótipo em Python de um aplicativo chamado **TriboFit**, inspirado nas telas e no cronograma fornecidos. O objetivo é oferecer uma experiência de terminal que represente as principais jornadas do produto: login, definição de objetivos, escolha de avatar, acompanhamento de treinos, feed social, comunidades, ranking e loja.
+
+## Como executar
+
+```bash
+python -m tribofit.cli
+```
+
+O script apresenta um menu interativo baseado nas seções planejadas para o app móvel. É possível definir objetivo, escolher avatar, registrar treinos concluídos e visualizar os conteúdos simulados.
+
+## Estrutura do projeto
+
+- `tribofit/app.py`: contém o núcleo da lógica do aplicativo, modelos de dados e geradores de telas.
+- `tribofit/cli.py`: expõe a interface de linha de comando que percorre as principais telas do app.
+- `exemplo.py`: função de saudação simples mantida do repositório original.
+
+## Próximos passos sugeridos
+
+1. Converter a experiência de terminal para uma interface gráfica (Flutter/React Native) seguindo o design fornecido.
+2. Integrar um backend com autenticação real, agendamento de treinos e sincronização de comunidades.
+3. Criar testes automatizados para garantir a consistência das jornadas principais.
+4. Evoluir o módulo de loja para suportar pagamentos e gerenciamento de estoque.
+5. Implementar notificações push e gamificação (ranking dinâmico, desafios e recompensas).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Protótipo em Python de um aplicativo chamado **TriboFit**, inspirado nas telas e no cronograma fornecidos. O objetivo é oferecer uma experiência de terminal que represente as principais jornadas do produto: login, definição de objetivos, escolha de avatar, acompanhamento de treinos, feed social, comunidades, ranking e loja.
 
-## Como executar
+## Como executar a CLI
 
 ```bash
 python -m tribofit.cli
@@ -10,10 +10,21 @@ python -m tribofit.cli
 
 O script apresenta um menu interativo baseado nas seções planejadas para o app móvel. É possível definir objetivo, escolher avatar, registrar treinos concluídos e visualizar os conteúdos simulados.
 
+## Como visualizar em HTML
+
+Para experimentar uma versão navegável em HTML, execute:
+
+```bash
+python -m tribofit.web
+```
+
+O servidor irá disponibilizar a interface em `http://127.0.0.1:8000`, exibindo as mesmas jornadas simuladas com um layout inspirado no design original.
+
 ## Estrutura do projeto
 
 - `tribofit/app.py`: contém o núcleo da lógica do aplicativo, modelos de dados e geradores de telas.
 - `tribofit/cli.py`: expõe a interface de linha de comando que percorre as principais telas do app.
+- `tribofit/web.py`: servidor HTTP simples que renderiza o protótipo em HTML.
 - `exemplo.py`: função de saudação simples mantida do repositório original.
 
 ## Próximos passos sugeridos

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,12 @@
 """Unit tests for the TriboFit application core."""
-from tribofit.app import TriboFitApp, build_demo_app
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tribofit.app import TriboFitApp, build_demo_app  # noqa: E402
+from tribofit.web import render_homepage  # noqa: E402
 
 
 def test_login_and_welcome_screen():
@@ -28,6 +35,16 @@ def test_complete_workout_updates_summary():
     assert "Força" in summary
     assert "Alpha" in summary
     assert "Agachamento" in summary
+
+
+def test_render_homepage_contains_sections():
+    app = build_demo_app()
+    html = render_homepage(app)
+
+    assert "<h2>Objetivos</h2>" in html
+    assert "<h2>Treino do Dia</h2>" in html
+    assert "Loja" in html
+    assert "@triber" in html
 
 
 def test_invalid_options_raise_errors():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,48 @@
+"""Unit tests for the TriboFit application core."""
+from tribofit.app import TriboFitApp, build_demo_app
+
+
+def test_login_and_welcome_screen():
+    app = TriboFitApp()
+    message = app.login("@ana.fit")
+    assert "@ana.fit" in message
+    assert "@ana.fit" in app.welcome_screen()
+
+
+def test_select_objective_and_avatar():
+    app = TriboFitApp()
+    app.login("@beta")
+    selected_objective = app.select_objective("Força")
+    selected_avatar = app.choose_avatar("Alpha")
+
+    assert selected_objective.name == "Força"
+    assert app.user and app.user.objective == selected_objective
+    assert selected_avatar.name == "Alpha"
+    assert app.user and app.user.avatar == selected_avatar
+
+
+def test_complete_workout_updates_summary():
+    app = build_demo_app()
+    summary = app.get_summary()
+    assert "@triber" in summary
+    assert "Força" in summary
+    assert "Alpha" in summary
+    assert "Agachamento" in summary
+
+
+def test_invalid_options_raise_errors():
+    app = TriboFitApp()
+    app.login("@gamma")
+    try:
+        app.select_objective("Inexistente")
+    except ValueError as exc:
+        assert "não encontrado" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("ValueError esperado para objetivo inválido")
+
+    try:
+        app.choose_avatar("Fantasma")
+    except ValueError as exc:
+        assert "não encontrado" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("ValueError esperado para avatar inválido")

--- a/tribofit/__init__.py
+++ b/tribofit/__init__.py
@@ -1,0 +1,5 @@
+"""TriboFit CLI simulation package."""
+
+from .app import TriboFitApp
+
+__all__ = ["TriboFitApp"]

--- a/tribofit/__init__.py
+++ b/tribofit/__init__.py
@@ -1,5 +1,11 @@
-"""TriboFit CLI simulation package."""
+"""TriboFit simulation package."""
 
-from .app import TriboFitApp
+from .app import TriboFitApp, build_demo_app
+from .web import render_homepage, run_web_server
 
-__all__ = ["TriboFitApp"]
+__all__ = [
+    "TriboFitApp",
+    "build_demo_app",
+    "render_homepage",
+    "run_web_server",
+]

--- a/tribofit/app.py
+++ b/tribofit/app.py
@@ -1,0 +1,247 @@
+"""Core application logic for the TriboFit CLI experience."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Objective:
+    """Represents a training objective."""
+
+    name: str
+    description: str
+
+
+@dataclass
+class Workout:
+    """Represents a workout exercise."""
+
+    name: str
+    repetitions: int
+    instructions: str
+
+
+@dataclass
+class Avatar:
+    """Represents a selectable avatar."""
+
+    name: str
+    archetype: str
+    description: str
+
+
+@dataclass
+class Community:
+    """Represents a TriboFit community."""
+
+    name: str
+    focus: str
+    members: int
+
+
+@dataclass
+class RankingEntry:
+    """Represents a ranking leaderboard entry."""
+
+    username: str
+    workouts_completed: int
+    streak_days: int
+
+
+@dataclass
+class StoreItem:
+    """Represents an item from the TriboFit store."""
+
+    name: str
+    category: str
+    price: float
+
+
+@dataclass
+class User:
+    """Represents a TriboFit user profile."""
+
+    username: str
+    avatar: Optional[Avatar] = None
+    objective: Optional[Objective] = None
+    completed_workouts: List[str] = field(default_factory=list)
+
+
+class TriboFitApp:
+    """A lightweight in-terminal simulation of the TriboFit experience."""
+
+    def __init__(self) -> None:
+        self.user: Optional[User] = None
+        self.objectives = self._load_objectives()
+        self.workouts = self._load_workouts()
+        self.avatars = self._load_avatars()
+        self.communities = self._load_communities()
+        self.ranking = self._load_ranking()
+        self.store_items = self._load_store()
+
+    # ------------------------------------------------------------------
+    # Data loading helpers
+    # ------------------------------------------------------------------
+    def _load_objectives(self) -> List[Objective]:
+        return [
+            Objective("Condicionamento", "Ganhe resistência com treinos focados em cardio."),
+            Objective("Força", "Construa músculos com rotinas de força progressiva."),
+            Objective("Equilíbrio", "Melhore sua postura e estabilidade com treinos funcionais."),
+        ]
+
+    def _load_workouts(self) -> List[Workout]:
+        return [
+            Workout("Agachamento", 15, "Agache mantendo as costas retas e os joelhos alinhados."),
+            Workout("Flexão", 12, "Mantenha o core firme e desça até 90 graus."),
+            Workout("Prancha", 1, "Sustente a posição de prancha por 60 segundos."),
+        ]
+
+    def _load_avatars(self) -> List[Avatar]:
+        return [
+            Avatar("Alpha", "Explorador", "Equilibrado, ótimo para quem gosta de desafios variados."),
+            Avatar("Nitro", "Velocista", "Ideal para quem busca treinos explosivos e cardio intenso."),
+            Avatar("FurBot", "Suporte", "Focado em mobilidade e treinos de recuperação."),
+        ]
+
+    def _load_communities(self) -> List[Community]:
+        return [
+            Community("Projeto Verão", "Resultados rápidos", 1820),
+            Community("Crossfit Lovers", "WODs diários", 2450),
+            Community("Yoga Mind", "Equilíbrio corpo e mente", 980),
+        ]
+
+    def _load_ranking(self) -> List[RankingEntry]:
+        return [
+            RankingEntry("@diana_f", 86, 21),
+            RankingEntry("@mauro.fit", 64, 14),
+            RankingEntry("@bianca_runs", 59, 11),
+        ]
+
+    def _load_store(self) -> List[StoreItem]:
+        return [
+            StoreItem("Bandas Elásticas", "Acessórios", 79.90),
+            StoreItem("Garrafa Térmica", "Acessórios", 59.90),
+            StoreItem("Camiseta TriboFit", "Roupas", 99.90),
+        ]
+
+    # ------------------------------------------------------------------
+    # User actions
+    # ------------------------------------------------------------------
+    def login(self, username: str) -> str:
+        """Simulate a login returning a welcome message."""
+        self.user = User(username=username)
+        return f"Bem-vindo de volta, {username}!"
+
+    def select_objective(self, objective_name: str) -> Objective:
+        if not self.user:
+            raise ValueError("Nenhum usuário logado.")
+        for obj in self.objectives:
+            if obj.name == objective_name:
+                self.user.objective = obj
+                return obj
+        raise ValueError(f"Objetivo '{objective_name}' não encontrado.")
+
+    def choose_avatar(self, avatar_name: str) -> Avatar:
+        if not self.user:
+            raise ValueError("Nenhum usuário logado.")
+        for avatar in self.avatars:
+            if avatar.name == avatar_name:
+                self.user.avatar = avatar
+                return avatar
+        raise ValueError(f"Avatar '{avatar_name}' não encontrado.")
+
+    def complete_workout(self, workout_name: str) -> Workout:
+        if not self.user:
+            raise ValueError("Nenhum usuário logado.")
+        for workout in self.workouts:
+            if workout.name == workout_name:
+                self.user.completed_workouts.append(workout_name)
+                return workout
+        raise ValueError(f"Treino '{workout_name}' não encontrado.")
+
+    # ------------------------------------------------------------------
+    # Screen builders (return textual representation)
+    # ------------------------------------------------------------------
+    def welcome_screen(self) -> str:
+        username = self.user.username if self.user else "visitante"
+        return (
+            "TRIBO.FIT\n"
+            f"Bem-vindo, {username}!\n"
+            "Próximo treino em 3h\n"
+            "1) Comunidade\n2) Lojas\n3) Ranking\n"
+        )
+
+    def objectives_screen(self) -> str:
+        lines = ["Objetivos:"]
+        for obj in self.objectives:
+            lines.append(f"- {obj.name}: {obj.description}")
+        return "\n".join(lines)
+
+    def avatars_screen(self) -> str:
+        lines = ["Escolha seu avatar:"]
+        for avatar in self.avatars:
+            lines.append(
+                f"- {avatar.name} ({avatar.archetype}): {avatar.description}"
+            )
+        return "\n".join(lines)
+
+    def training_screen(self) -> str:
+        lines = ["Treino do dia:"]
+        for workout in self.workouts:
+            lines.append(f"- {workout.name} x{workout.repetitions}: {workout.instructions}")
+        return "\n".join(lines)
+
+    def feed_screen(self) -> str:
+        return (
+            "Feed:\n"
+            "@diana_f concluiu o Desafio Nitro.\n"
+            "@mauro.fit compartilhou um novo WOD.\n"
+            "@bianca_runs comemorou 30 dias de streak!"
+        )
+
+    def community_screen(self) -> str:
+        lines = ["Comunidades disponíveis:"]
+        for community in self.communities:
+            lines.append(
+                f"- {community.name}: {community.focus} ({community.members} membros)"
+            )
+        return "\n".join(lines)
+
+    def ranking_screen(self) -> str:
+        lines = ["Ranking Fitness:"]
+        for index, entry in enumerate(self.ranking, start=1):
+            lines.append(
+                f"{index}. {entry.username} - {entry.workouts_completed} treinos, {entry.streak_days} dias de streak"
+            )
+        return "\n".join(lines)
+
+    def store_screen(self) -> str:
+        lines = ["Loja TriboFit:"]
+        for item in self.store_items:
+            lines.append(f"- {item.name} ({item.category}) - R$ {item.price:.2f}")
+        return "\n".join(lines)
+
+    def get_summary(self) -> str:
+        if not self.user:
+            raise ValueError("Nenhum usuário logado.")
+        objective = self.user.objective.name if self.user.objective else "Nenhum"
+        avatar = self.user.avatar.name if self.user.avatar else "Nenhum"
+        workouts = ", ".join(self.user.completed_workouts) or "Nenhum"
+        return (
+            "Resumo do perfil:\n"
+            f"Usuário: {self.user.username}\n"
+            f"Objetivo: {objective}\n"
+            f"Avatar: {avatar}\n"
+            f"Treinos concluídos: {workouts}"
+        )
+
+
+def build_demo_app() -> TriboFitApp:
+    """Helper to build an app preloaded with demo selections."""
+    app = TriboFitApp()
+    app.login("@triber")
+    app.select_objective("Força")
+    app.choose_avatar("Alpha")
+    app.complete_workout("Agachamento")
+    return app

--- a/tribofit/cli.py
+++ b/tribofit/cli.py
@@ -1,0 +1,90 @@
+"""Command line interface for the TriboFit simulation."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .app import TriboFitApp
+
+
+MENU_OPTIONS: Dict[str, Callable[[TriboFitApp], str]] = {
+    "1": TriboFitApp.objectives_screen,
+    "2": TriboFitApp.avatars_screen,
+    "3": TriboFitApp.training_screen,
+    "4": TriboFitApp.feed_screen,
+    "5": TriboFitApp.community_screen,
+    "6": TriboFitApp.ranking_screen,
+    "7": TriboFitApp.store_screen,
+    "8": TriboFitApp.get_summary,
+}
+
+
+def run_cli() -> None:
+    """Launch an interactive text-based session."""
+    app = TriboFitApp()
+    username = input("Digite seu usuário TriboFit: ")
+    print(app.login(username))
+
+    while True:
+        print()
+        print(app.welcome_screen())
+        print("Escolha uma opção:")
+        print("1) Ver objetivos")
+        print("2) Escolher avatar")
+        print("3) Ver treino do dia")
+        print("4) Abrir feed")
+        print("5) Explorar comunidades")
+        print("6) Ver ranking")
+        print("7) Visitar loja")
+        print("8) Resumo do perfil")
+        print("9) Registrar treino concluído")
+        print("0) Sair")
+
+        choice = input("> ").strip()
+
+        if choice == "0":
+            print("Até logo, continue firme nos treinos!")
+            break
+
+        if choice == "2":
+            print(app.avatars_screen())
+            avatar_name = input("Digite o nome do avatar escolhido: ").strip()
+            try:
+                selected = app.choose_avatar(avatar_name)
+                print(f"Avatar selecionado: {selected.name}")
+            except ValueError as exc:
+                print(exc)
+            continue
+
+        if choice == "1":
+            print(app.objectives_screen())
+            objective_name = input("Digite o nome do objetivo: ").strip()
+            try:
+                selected = app.select_objective(objective_name)
+                print(f"Objetivo definido: {selected.name}")
+            except ValueError as exc:
+                print(exc)
+            continue
+
+        if choice == "9":
+            print(app.training_screen())
+            workout_name = input("Qual treino você completou? ").strip()
+            try:
+                workout = app.complete_workout(workout_name)
+                print(f"Parabéns! Você concluiu {workout.name} x{workout.repetitions}.")
+            except ValueError as exc:
+                print(exc)
+            continue
+
+        action = MENU_OPTIONS.get(choice)
+        if not action:
+            print("Opção inválida, tente novamente.")
+            continue
+
+        try:
+            print(action(app))
+        except ValueError as exc:
+            print(exc)
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/tribofit/web.py
+++ b/tribofit/web.py
@@ -1,0 +1,258 @@
+"""Minimal HTTP server that renders the TriboFit prototype as HTML."""
+from __future__ import annotations
+
+from html import escape
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Iterable
+
+from .app import TriboFitApp, build_demo_app
+
+
+def _render_list(items: Iterable[str]) -> str:
+    return "".join(f"<li>{escape(item)}</li>" for item in items)
+
+
+def render_homepage(app: TriboFitApp) -> str:
+    """Return an HTML page representing the TriboFit experience."""
+
+    user = app.user.username if app.user else "Visitante"
+    objective = app.user.objective.name if app.user and app.user.objective else "Nenhum"
+    avatar = app.user.avatar.name if app.user and app.user.avatar else "Nenhum"
+    completed = app.user.completed_workouts if app.user else []
+
+    objectives = _render_list(
+        f"{item.name} — {item.description}" for item in app.objectives
+    )
+    avatars = _render_list(
+        f"{item.name} ({item.archetype}) — {item.description}" for item in app.avatars
+    )
+    workouts = _render_list(
+        f"{item.name} ×{item.repetitions}: {item.instructions}" for item in app.workouts
+    )
+    feed = _render_list(
+        [
+            "@diana_f concluiu o Desafio Nitro.",
+            "@mauro.fit compartilhou um novo WOD.",
+            "@bianca_runs comemorou 30 dias de streak!",
+        ]
+    )
+    communities = _render_list(
+        f"{item.name} — {item.focus} ({item.members} membros)" for item in app.communities
+    )
+    ranking = _render_list(
+        f"{index}. {entry.username} — {entry.workouts_completed} treinos · {entry.streak_days} dias"
+        for index, entry in enumerate(app.ranking, start=1)
+    )
+    store = _render_list(
+        f"{item.name} ({item.category}) — R$ {item.price:.2f}" for item in app.store_items
+    )
+    completed_workouts = (
+        _render_list(completed)
+        if completed
+        else '<li class="placeholder">Nenhum treino concluído ainda</li>'
+    )
+
+    return f"""
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <title>TriboFit — protótipo web</title>
+    <style>
+      :root {{
+        color-scheme: light dark;
+        font-family: 'Segoe UI', system-ui, sans-serif;
+        background: #0b0d16;
+        color: #f5f5f5;
+      }}
+      body {{
+        margin: 0;
+        padding: 0;
+        background: radial-gradient(circle at top, #111831 0%, #05070d 70%);
+        min-height: 100vh;
+      }}
+      header {{
+        padding: 2.5rem 1.5rem 1rem;
+        text-align: center;
+      }}
+      h1 {{
+        letter-spacing: 0.2rem;
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+        text-transform: uppercase;
+      }}
+      .tagline {{
+        color: #9fb4ff;
+        font-weight: 500;
+        margin: 0;
+      }}
+      main {{
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        padding: 0 1.5rem 2.5rem;
+      }}
+      section {{
+        background: rgba(17, 24, 49, 0.75);
+        border: 1px solid rgba(159, 180, 255, 0.15);
+        border-radius: 18px;
+        padding: 1.5rem;
+        box-shadow: 0 20px 40px rgba(3, 8, 24, 0.45);
+        backdrop-filter: blur(12px);
+      }}
+      h2 {{
+        font-size: 1.125rem;
+        margin-top: 0;
+        color: #9fb4ff;
+        text-transform: uppercase;
+        letter-spacing: 0.1rem;
+      }}
+      ul {{
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }}
+      li {{
+        background: rgba(5, 7, 13, 0.55);
+        border-radius: 12px;
+        padding: 0.75rem 1rem;
+        line-height: 1.4;
+        box-shadow: inset 0 0 0 1px rgba(159, 180, 255, 0.08);
+      }}
+      .summary-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem;
+      }}
+      .summary-card {{
+        background: linear-gradient(140deg, rgba(90, 120, 255, 0.4), rgba(3, 8, 24, 0.4));
+        border-radius: 14px;
+        padding: 1rem;
+        text-align: center;
+        border: 1px solid rgba(159, 180, 255, 0.25);
+      }}
+      .summary-card span {{
+        display: block;
+        font-size: 0.75rem;
+        letter-spacing: 0.08rem;
+        text-transform: uppercase;
+        color: rgba(245, 245, 245, 0.75);
+      }}
+      .summary-card strong {{
+        font-size: 1.25rem;
+      }}
+      .placeholder {{
+        color: rgba(245, 245, 245, 0.55);
+        font-style: italic;
+      }}
+      footer {{
+        text-align: center;
+        padding: 1.5rem;
+        color: rgba(245, 245, 245, 0.55);
+        font-size: 0.875rem;
+      }}
+      a {{
+        color: #9fb4ff;
+      }}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>TriboFit</h1>
+      <p class="tagline">Energia da tribo com foco no seu progresso diário</p>
+    </header>
+    <main>
+      <section>
+        <h2>Resumo</h2>
+        <div class="summary-grid">
+          <div class="summary-card">
+            <span>Usuário</span>
+            <strong>{escape(user)}</strong>
+          </div>
+          <div class="summary-card">
+            <span>Objetivo</span>
+            <strong>{escape(objective)}</strong>
+          </div>
+          <div class="summary-card">
+            <span>Avatar</span>
+            <strong>{escape(avatar)}</strong>
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2>Objetivos</h2>
+        <ul>{objectives}</ul>
+      </section>
+      <section>
+        <h2>Avatares</h2>
+        <ul>{avatars}</ul>
+      </section>
+      <section>
+        <h2>Treino do Dia</h2>
+        <ul>{workouts}</ul>
+      </section>
+      <section>
+        <h2>Feed da Tribo</h2>
+        <ul>{feed}</ul>
+      </section>
+      <section>
+        <h2>Comunidades</h2>
+        <ul>{communities}</ul>
+      </section>
+      <section>
+        <h2>Ranking</h2>
+        <ul>{ranking}</ul>
+      </section>
+      <section>
+        <h2>Loja</h2>
+        <ul>{store}</ul>
+      </section>
+      <section>
+        <h2>Treinos Concluídos</h2>
+        <ul>{completed_workouts}</ul>
+      </section>
+    </main>
+    <footer>
+      Visualização web do protótipo TriboFit. Ajuste os dados no servidor para testar novos cenários.
+    </footer>
+  </body>
+</html>
+"""
+
+
+class _TriboFitRequestHandler(BaseHTTPRequestHandler):
+    """Serve the TriboFit homepage for any GET request."""
+
+    demo_app: TriboFitApp = build_demo_app()
+
+    def do_GET(self) -> None:  # noqa: N802 (keep signature from BaseHTTPRequestHandler)
+        html = render_homepage(self.demo_app)
+        encoded = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, *_: object) -> None:  # pragma: no cover - silence default logs
+        return
+
+
+def run_web_server(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start a simple HTTP server that renders the TriboFit prototype."""
+
+    server = HTTPServer((host, port), _TriboFitRequestHandler)
+    print(f"TriboFit web disponível em http://{host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - manual shutdown
+        print("Encerrando servidor TriboFit...")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    run_web_server()


### PR DESCRIPTION
## Summary
- add a TriboFit domain model encapsulating objectives, treinos, comunidades, ranking e loja
- create an interactive CLI that percorre as telas principais do protótipo TriboFit
- documentar execução e próximos passos no README, além de cobrir fluxos principais com testes

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_b_68d7f9664b6083258ed0f0b8516ef298